### PR TITLE
Add suave-alpha redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 a simple tool for redirecting or returning custom responses. designed with the goal of having a single, simple service that can gently handle decommissioned api and websites.
 
-# usage
-
-1. add source and desired handling to `src/config.js`
-2. add a `route` for the domain to `wrangler.toml`
-3. on commit to `main` the worker is deployed by github actions
-4. update source cname record to `redirectorator.<account-name>.workers.dev`
-
 # run locally
 
 requires [wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/#install-wrangler). only one route from `wrangler.toml` can be active.
 
-activate the `localhost` route:
+activate the `test` route:
 ```sh
-make dev
+make dev            # start worker
+curl localhost:8787 # use worker
 ```
 
 activate a specific route with `HOST`:
 ```sh
 HOST=example.com make dev
 ```
+
+# usage
+
+1. add source and desired handling to `src/config.js`
+2. add a `route` for the domain to `wrangler.toml`
+3. on commit to `main` the worker is deployed by github actions
+4. update source cname record to `redirectorator.<account-name>.workers.dev`

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,22 @@
 export const config = {
   "defaultStatus": 410,
   "hosts": {
+    "suave-alpha.flashbots.net": {
+      routes: [
+        {
+          path: "/",
+          response: {
+            api: {
+              message: "This website has been decommissioned. Please visit writings.flashbots.net and join us at collective.flashbots.net"
+            },
+            web: {
+              message: "This website has been decommissioned. Please join us at the <a href='https://collective.flashbots.net'>Flashbots forum</a> and visit <a href='https://writings.flashbots.net'>writings.flashbots.net</a>.",
+              redirectUrl: "https://writings.flashbots.net/"
+            },
+          },
+        },
+      ]
+    },
     "blocks.flashbots.net": {
       routes: [
         {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2024-01-01"
 
 routes = [
   { pattern = "blocks.flashbots.net/*", zone_name = "flashbots.net" }
+  { pattern = "suave-alpha.flashbots.net/*", zone_name = "flashbots.net" }
 ]
 
 [observability.logs]


### PR DESCRIPTION
This pull request introduces updates to the configuration, documentation, and routing for the redirector service. The most notable changes include adding a new host configuration for `suave-alpha.flashbots.net`, updating the routing rules in `wrangler.toml`, and improving the `README.md` for better clarity and usability.

### Configuration Updates:
* [`src/config.js`](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR4-R19): Added a new host configuration for `suave-alpha.flashbots.net` with custom responses for both API and web requests, including a redirect URL and messages for decommissioning.

### Routing Updates:
* [`wrangler.toml`](diffhunk://#diff-b1b9719b6eae4103d520f1e902420f5073b5e18a5a47aa73feed71a037557c98R7): Added a new route pattern for `suave-alpha.flashbots.net/*` under the `flashbots.net` zone.

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R25): Reorganized the "usage" section for better readability, clarified the local development steps, and added an example `curl` command for testing the worker locally.