### PR TITLE
Add suave

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,23 @@
 export const config = {
   "defaultStatus": 410,
   "hosts": {
-    "suave-alpha.flashbots.net": {
+    "blocks.flashbots.net": {
+      routes: [
+        {
+          path: "/",
+          response: {
+            api: {
+              message: "This API has been decommissioned. You can visit datasets.flashbots.net for historical data and join us at collective.flashbots.net"
+            },
+            web: {
+              message: "This API has been decommissioned. You can visit <a href='https://datasets.flashbots.net'>datasets.flashbots.net</a> for historical data. Join us at the Flashbots forum.",
+              redirectUrl: "https://collective.flashbots.net/"
+            },
+          },
+        },
+      ]
+    },
+    "suave.flashbots.net": {
       routes: [
         {
           path: "/",
@@ -17,17 +33,17 @@ export const config = {
         },
       ]
     },
-    "blocks.flashbots.net": {
+    "suave-alpha.flashbots.net": {
       routes: [
         {
           path: "/",
           response: {
             api: {
-              message: "This API has been decommissioned. You can visit datasets.flashbots.net for historical data and join us at collective.flashbots.net"
+              message: "This website has been decommissioned. Please visit writings.flashbots.net and join us at collective.flashbots.net"
             },
             web: {
-              message: "This API has been decommissioned. You can visit <a href='https://datasets.flashbots.net'>datasets.flashbots.net</a> for historical data. Join us at the Flashbots forum.",
-              redirectUrl: "https://collective.flashbots.net/"
+              message: "This website has been decommissioned. Please join us at the <a href='https://collective.flashbots.net'>Flashbots forum</a> and visit <a href='https://writings.flashbots.net'>writings.flashbots.net</a>.",
+              redirectUrl: "https://writings.flashbots.net/"
             },
           },
         },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2024-01-01"
 
 routes = [
   { pattern = "blocks.flashbots.net/*", zone_name = "flashbots.net" },
+  { pattern = "suave.flashbots.net/*", zone_name = "flashbots.net" },
   { pattern = "suave-alpha.flashbots.net/*", zone_name = "flashbots.net" }
 ]
 


### PR DESCRIPTION
This pull request updates the configuration and routing for Flashbots services, reflecting changes in API decommissioning and redirecting users to updated resources. The most important changes include modifications to the `src/config.js` file to adjust host configurations and update decommissioning messages, as well as an addition to the routing patterns in `wrangler.toml`.

### Configuration Updates:
* [`src/config.js`](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cL4-R20): Replaced the host configuration for `suave-alpha.flashbots.net` and `blocks.flashbots.net`, updating decommissioning messages to direct users to new resources (`datasets.flashbots.net`, `writings.flashbots.net`, and `collective.flashbots.net`). [[1]](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cL4-R20) [[2]](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cL20-R46)

### Routing Updates:
* [`wrangler.toml`](diffhunk://#diff-b1b9719b6eae4103d520f1e902420f5073b5e18a5a47aa73feed71a037557c98R7): Added a new route pattern for `suave.flashbots.net` under the `flashbots.net` zone to ensure proper routing.